### PR TITLE
feat: Add IRIS-HEP environment for Python 3.8 and 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.11']
+        python-version: ['3.8', '3.11']
     # if: >-
     #   github.event_name != 'push'
     #   || (github.event_name == 'push' && github.ref == 'refs/heads/main')
@@ -170,6 +170,11 @@ jobs:
       with:
         name: iris-hep-3.11
         path: '_site/iris-hep/3.11/'
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: iris-hep-3.8
+        path: '_site/iris-hep/3.8/'
 
     - name: Check site structure
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.11']
-    # if: >-
-    #   github.event_name != 'push'
-    #   || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: >-
+      github.event_name != 'push'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
     steps:
     - name: Checkout code
@@ -89,9 +89,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.11']
-    # if: >-
-    #   github.event_name != 'push'
-    #   || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: >-
+      github.event_name != 'push'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
     steps:
     - name: Checkout code
@@ -143,7 +143,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: [scikit-hep, iris-hep]
-    # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.11']
-    if: >-
-      github.event_name != 'push'
-      || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    # if: >-
+    #   github.event_name != 'push'
+    #   || (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
     steps:
     - name: Checkout code
@@ -89,9 +89,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.11']
-    if: >-
-      github.event_name != 'push'
-      || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    # if: >-
+    #   github.event_name != 'push'
+    #   || (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
     steps:
     - name: Checkout code
@@ -143,7 +143,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: [scikit-hep, iris-hep]
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
     - name: Create site directory structure
       run: |
         cp -r scikit-hep _site/
+        cp -r iris-hep _site/
 
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,68 @@ jobs:
           requirements.lock
           conda-lock.yml
 
+  iris-hep:
+
+    runs-on: ${{ matrix.os }}
+    # On push events run the CI only on main by default
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.11']
+    if: >-
+      github.event_name != 'push'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip-tools
+
+    - name: Build lock file
+      run: |
+        pip-compile \
+          --resolver=backtracking \
+          --generate-hashes \
+          --output-file requirements.lock \
+          iris-hep/${{ matrix.python-version }}/requirements.txt
+
+    - name: Install micromamba and conda-lock
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-name: conda-lock
+        create-args: >-
+          python=${{ matrix.python-version }}
+          conda-lock
+
+    - name: Build conda-lock lock file
+      run: |
+        conda-lock \
+            --file iris-hep/${{ matrix.python-version }}/environment.yml \
+            --lockfile conda-lock.yml
+
+    - name: Upload lock files
+      uses: actions/upload-artifact@v3
+      with:
+        name: iris-hep-${{ matrix.python-version }}
+        path: |
+          requirements.lock
+          conda-lock.yml
+
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: [scikit-hep]
+    needs: [scikit-hep, iris-hep]
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
 
     steps:
@@ -109,6 +165,11 @@ jobs:
       with:
         name: scikit-hep-3.11
         path: '_site/scikit-hep/3.11/'
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: iris-hep-3.11
+        path: '_site/iris-hep/3.11/'
 
     - name: Check site structure
       run: |

--- a/_site/index.html
+++ b/_site/index.html
@@ -88,5 +88,26 @@
 
   </ul>
 
+  <h2>iris-hep</h2>
+
+  <ul>
+
+    <li>Python 3.11
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-system-env-nightlies/iris-hep/3.11/requirements.txt">requirements.txt (high level)</a></li>
+      </ul>
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-system-env-nightlies/iris-hep/3.11/requirements.lock">requirements.lock</a></li>
+      </ul>
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-system-env-nightlies/iris-hep/3.11/environment.yml">environment.yml (high level)</a></li>
+      </ul>
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-system-env-nightlies/iris-hep/3.11/conda-lock.yml">conda-lock.yml</a></li>
+      </ul>
+    </li>
+
+  </ul>
+
 </body>
 </html>

--- a/_site/index.html
+++ b/_site/index.html
@@ -32,14 +32,14 @@
   <b>Python 3.11 pip example:</b>
 
   <p style="font-family:'Lucida Console', monospace">
-  python -m pip install --upgrade --require-hashes --requirement https://iris-hep.org/analysis-system-env-nightlies/scikit-hep/3.11/requirements.lock
+  python -m pip install --upgrade --require-hashes --requirement https://iris-hep.org/analysis-system-env-nightlies/iris-hep/3.11/requirements.lock
   </p>
 
 
   <b>Python 3.11 conda-lock example:</b>
 
   <p style="font-family:'Lucida Console', monospace">
-  micromamba create --name scikit-hep --file https://iris-hep.org/analysis-system-env-nightlies/scikit-hep/3.11/conda-lock.yml
+  micromamba create --name iris-hep --file https://iris-hep.org/analysis-system-env-nightlies/iris-hep/3.11/conda-lock.yml
   </p>
 
   or
@@ -47,9 +47,9 @@
   <p style="font-family:'Lucida Console', monospace">
   # conda-lock install doesn't work with urls
   <br>
-  curl -sLO https://iris-hep.org/analysis-system-env-nightlies/scikit-hep/3.11/conda-lock.yml
+  curl -sLO https://iris-hep.org/analysis-system-env-nightlies/iris-hep/3.11/conda-lock.yml
   <br>
-  conda-lock install --name scikit-hep conda-lock.yml
+  conda-lock install --name iris-hep conda-lock.yml
   </p>
 
   <h2>scikit-hep</h2>

--- a/_site/index.html
+++ b/_site/index.html
@@ -107,6 +107,21 @@
       </ul>
     </li>
 
+    <li>Python 3.8
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-system-env-nightlies/iris-hep/3.8/requirements.txt">requirements.txt (high level)</a></li>
+      </ul>
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-system-env-nightlies/iris-hep/3.8/requirements.lock">requirements.lock</a></li>
+      </ul>
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-system-env-nightlies/iris-hep/3.8/environment.yml">environment.yml (high level)</a></li>
+      </ul>
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-system-env-nightlies/iris-hep/3.8/conda-lock.yml">conda-lock.yml</a></li>
+      </ul>
+    </li>
+
   </ul>
 
 </body>

--- a/iris-hep/3.11/environment.yml
+++ b/iris-hep/3.11/environment.yml
@@ -1,0 +1,29 @@
+name: scikit-hep
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3.11
+  # Scikit-HEP
+  - uproot>=5.0.0
+  - hist>=2.7.0
+  - mplhep>=0.2.16  # hist[plot]
+  - cabinetry>=0.5.2
+  - awkward  # versions controlled through uproot
+  - vector  # versions controlled through fastjet
+  - iminuit  # versions controlled through cabinetry
+  - pyhf  # versions controlled through cabinetry
+  # IRIS-HEP
+  - dask-awkward  # versions controlled through coffea
+  # pip dependencies
+  - pip
+  - pip:
+    - fastjet>=3.4.0.0
+    - coffea>=2023.7.0rc0
+    - servicex>=3.0.0a4
+    - func_adl  # versions controlled through servicex
+
+# conda-lock only
+platforms:
+  - linux-64

--- a/iris-hep/3.11/requirements.txt
+++ b/iris-hep/3.11/requirements.txt
@@ -1,0 +1,14 @@
+# Scikit-HEP
+uproot>=5.0.0
+hist[plot]>=2.7.0
+fastjet>=3.4.0.0
+cabinetry>=0.5.2
+awkward  # versions controlled through uproot
+vector  # versions controlled through fastjet
+iminuit  # versions controlled through cabinetry
+pyhf  # versions controlled through cabinetry
+# IRIS-HEP
+coffea>=2023.7.0rc0
+servicex>=3.0.0a4
+dask-awkward  # versions controlled through coffea
+func_adl  # versions controlled through servicex

--- a/iris-hep/3.8/environment.yml
+++ b/iris-hep/3.8/environment.yml
@@ -1,0 +1,29 @@
+name: scikit-hep
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3.8
+  # Scikit-HEP
+  - uproot>=5.0.0
+  - hist>=2.7.0
+  - mplhep>=0.2.16  # hist[plot]
+  - cabinetry>=0.5.2
+  - awkward  # versions controlled through uproot
+  - vector  # versions controlled through fastjet
+  - iminuit  # versions controlled through cabinetry
+  - pyhf  # versions controlled through cabinetry
+  # IRIS-HEP
+  - dask-awkward  # versions controlled through coffea
+  # pip dependencies
+  - pip
+  - pip:
+    - fastjet>=3.4.0.0
+    - coffea>=2023.7.0rc0
+    - servicex>=3.0.0a4
+    - func_adl  # versions controlled through servicex
+
+# conda-lock only
+platforms:
+  - linux-64

--- a/iris-hep/3.8/requirements.txt
+++ b/iris-hep/3.8/requirements.txt
@@ -1,0 +1,14 @@
+# Scikit-HEP
+uproot>=5.0.0
+hist[plot]>=2.7.0
+fastjet>=3.4.0.0
+cabinetry>=0.5.2
+awkward  # versions controlled through uproot
+vector  # versions controlled through fastjet
+iminuit  # versions controlled through cabinetry
+pyhf  # versions controlled through cabinetry
+# IRIS-HEP
+coffea>=2023.7.0rc0
+servicex>=3.0.0a4
+dask-awkward  # versions controlled through coffea
+func_adl  # versions controlled through servicex


### PR DESCRIPTION
```
* Add Python 3.8, 3.11 environment files for IRIS-HEP tools, which is mostly
  the Scikit-HEP environment plus coffea and servicex.
* Add environment file links to webpage.
* Add iris-hep lock file build job to CI.
* Update examples on webpage to use IRIS-HEP environment.
```