### PR TITLE
docs: Add --micromamba option to conda-lock install example

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -49,7 +49,9 @@
   <br>
   curl -sLO https://iris-hep.org/analysis-system-env-nightlies/iris-hep/3.11/conda-lock.yml
   <br>
-  conda-lock install --name iris-hep conda-lock.yml
+  # c.f. conda-lock install --help
+  <br>
+  conda-lock install --micromamba --name iris-hep conda-lock.yml
   </p>
 
   <h2>scikit-hep</h2>


### PR DESCRIPTION
* Use the `conda-lock install` `--micromamba` option in the usage example so that if people are following along from the previous example of using `micromamba create` they will get a valid micromamba environment.