### PR TITLE
ci: Add deploy time in UTC as metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,11 @@ jobs:
         name: iris-hep-3.8
         path: '_site/iris-hep/3.8/'
 
+    - name: Add deploy time in UTC to site
+      run: |
+        mkdir -p _site/metadata
+        date -u +"%Y-%m-%d %H:%M %Z" > _site/metadata/deploy-time.txt
+
     - name: Check site structure
       run: |
         tree _site


### PR DESCRIPTION
* In the event that knowing when the last time the site was deployed is useful without looking at the GitHub logs, this provides a way to query it easily.