### PR TITLE
feat: Update servicex lower bound to v2.7.0

### DIFF
--- a/iris-hep/3.11/environment.yml
+++ b/iris-hep/3.11/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - pip:
     - fastjet>=3.4.0.0
     - coffea>=2023.7.0rc0
-    - servicex>=3.0.0a4
+    - servicex>=2.7.0
     - func-adl-servicex>=2.2
     - func-adl  # versions controlled through servicex
 

--- a/iris-hep/3.11/requirements.txt
+++ b/iris-hep/3.11/requirements.txt
@@ -9,7 +9,7 @@ iminuit  # versions controlled through cabinetry
 pyhf  # versions controlled through cabinetry
 # IRIS-HEP
 coffea>=2023.7.0rc0
-servicex>=3.0.0a4
+servicex>=2.7.0
 func-adl-servicex>=2.2
 xrootd>=5.6.2
 dask-awkward  # versions controlled through coffea

--- a/iris-hep/3.8/environment.yml
+++ b/iris-hep/3.8/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - pip:
     - fastjet>=3.4.0.0
     - coffea>=2023.7.0rc0
-    - servicex>=3.0.0a4
+    - servicex>=2.7.0
     - func-adl-servicex>=2.2
     - func-adl  # versions controlled through servicex
 

--- a/iris-hep/3.8/requirements.txt
+++ b/iris-hep/3.8/requirements.txt
@@ -9,7 +9,7 @@ iminuit  # versions controlled through cabinetry
 pyhf  # versions controlled through cabinetry
 # IRIS-HEP
 coffea>=2023.7.0rc0
-servicex>=3.0.0a4
+servicex>=2.7.0
 func-adl-servicex>=2.2
 xrootd>=5.6.2
 dask-awkward  # versions controlled through coffea


### PR DESCRIPTION
Resolves #16 

* c.f. https://github.com/ssl-hep/ServiceX_frontend/releases/tag/v2.7.0
   - servicex v2.7.0 brings support for Awkward v2.0.