### PR TITLE
feat: Distinguish between IRIS-HEP stable and release candidates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,12 +137,68 @@ jobs:
           requirements.lock
           conda-lock.yml
 
+  iris-hep-rc:
+
+    runs-on: ${{ matrix.os }}
+    # On push events run the CI only on main by default
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.8', '3.11']
+    if: >-
+      github.event_name != 'push'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip-tools
+
+    - name: Build lock file
+      run: |
+        pip-compile \
+          --resolver=backtracking \
+          --generate-hashes \
+          --output-file requirements.lock \
+          iris-hep-rc/${{ matrix.python-version }}/requirements.txt
+
+    - name: Install micromamba and conda-lock
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-name: conda-lock
+        create-args: >-
+          python=${{ matrix.python-version }}
+          conda-lock
+
+    - name: Build conda-lock lock file
+      run: |
+        conda-lock \
+            --file iris-hep-rc/${{ matrix.python-version }}/environment.yml \
+            --lockfile conda-lock.yml
+
+    - name: Upload lock files
+      uses: actions/upload-artifact@v3
+      with:
+        name: iris-hep-rc-${{ matrix.python-version }}
+        path: |
+          requirements.lock
+          conda-lock.yml
+
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: [scikit-hep, iris-hep]
+    needs: [scikit-hep, iris-hep, iris-hep-rc]
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
 
     steps:
@@ -176,6 +232,16 @@ jobs:
       with:
         name: iris-hep-3.8
         path: '_site/iris-hep/3.8/'
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: iris-hep-rc-3.11
+        path: '_site/iris-hep-rc/3.11/'
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: iris-hep-rc-3.8
+        path: '_site/iris-hep-rc/3.8/'
 
     - name: Add deploy time in UTC to site
       run: |

--- a/_site/index.html
+++ b/_site/index.html
@@ -126,5 +126,41 @@
 
   </ul>
 
+  <h2>iris-hep release candidates</h2>
+
+  <ul>
+
+    <li>Python 3.11
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-systems-env-nightlies/iris-hep-rc/3.11/requirements.txt">requirements.txt (high level)</a></li>
+      </ul>
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-systems-env-nightlies/iris-hep-rc/3.11/requirements.lock">requirements.lock</a></li>
+      </ul>
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-systems-env-nightlies/iris-hep-rc/3.11/environment.yml">environment.yml (high level)</a></li>
+      </ul>
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-systems-env-nightlies/iris-hep-rc/3.11/conda-lock.yml">conda-lock.yml</a></li>
+      </ul>
+    </li>
+
+    <li>Python 3.8
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-systems-env-nightlies/iris-hep-rc/3.8/requirements.txt">requirements.txt (high level)</a></li>
+      </ul>
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-systems-env-nightlies/iris-hep-rc/3.8/requirements.lock">requirements.lock</a></li>
+      </ul>
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-systems-env-nightlies/iris-hep-rc/3.8/environment.yml">environment.yml (high level)</a></li>
+      </ul>
+      <ul>
+          <li><a href="https://iris-hep.org/analysis-systems-env-nightlies/iris-hep-rc/3.8/conda-lock.yml">conda-lock.yml</a></li>
+      </ul>
+    </li>
+
+  </ul>
+
 </body>
 </html>

--- a/iris-hep-rc/3.11/environment.yml
+++ b/iris-hep-rc/3.11/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - pip:
     - fastjet>=3.4.0.0
     - coffea>=2023.7.0rc0
-    - servicex>=2.7.0
+    - servicex>=3.0.0a6
     - func-adl-servicex>=2.2
     - func-adl  # versions controlled through servicex
 

--- a/iris-hep-rc/3.11/environment.yml
+++ b/iris-hep-rc/3.11/environment.yml
@@ -1,0 +1,31 @@
+name: iris-hep
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3.11
+  # Scikit-HEP
+  - uproot>=5.0.0
+  - hist>=2.7.0
+  - mplhep>=0.2.16  # hist[plot]
+  - cabinetry>=0.5.2
+  - awkward  # versions controlled through uproot
+  - vector  # versions controlled through fastjet
+  - iminuit  # versions controlled through cabinetry
+  - pyhf  # versions controlled through cabinetry
+  # IRIS-HEP
+  - dask-awkward  # versions controlled through coffea
+  - xrootd>=5.6.2
+  # pip dependencies
+  - pip
+  - pip:
+    - fastjet>=3.4.0.0
+    - coffea>=2023.7.0rc0
+    - servicex>=2.7.0
+    - func-adl-servicex>=2.2
+    - func-adl  # versions controlled through servicex
+
+# conda-lock only
+platforms:
+  - linux-64

--- a/iris-hep-rc/3.11/requirements.txt
+++ b/iris-hep-rc/3.11/requirements.txt
@@ -1,0 +1,16 @@
+# Scikit-HEP
+uproot>=5.0.0
+hist[plot]>=2.7.0
+fastjet>=3.4.0.0
+cabinetry>=0.5.2
+awkward  # versions controlled through uproot
+vector  # versions controlled through fastjet
+iminuit  # versions controlled through cabinetry
+pyhf  # versions controlled through cabinetry
+# IRIS-HEP
+coffea>=2023.7.0rc0
+servicex>=2.7.0
+func-adl-servicex>=2.2
+xrootd>=5.6.2
+dask-awkward  # versions controlled through coffea
+func-adl  # versions controlled through servicex

--- a/iris-hep-rc/3.11/requirements.txt
+++ b/iris-hep-rc/3.11/requirements.txt
@@ -10,7 +10,7 @@ iminuit  # versions controlled through cabinetry
 pyhf  # versions controlled through cabinetry
 # IRIS-HEP
 coffea>=2023.7.0rc0
-servicex>=2.7.0
+servicex>=3.0.0a6
 func-adl-servicex>=2.2
 xrootd>=5.6.2
 dask-awkward  # versions controlled through coffea

--- a/iris-hep-rc/3.11/requirements.txt
+++ b/iris-hep-rc/3.11/requirements.txt
@@ -1,3 +1,4 @@
+--pre
 # Scikit-HEP
 uproot>=5.0.0
 hist[plot]>=2.7.0

--- a/iris-hep-rc/3.8/environment.yml
+++ b/iris-hep-rc/3.8/environment.yml
@@ -1,0 +1,31 @@
+name: iris-hep
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3.8
+  # Scikit-HEP
+  - uproot>=5.0.0
+  - hist>=2.7.0
+  - mplhep>=0.2.16  # hist[plot]
+  - cabinetry>=0.5.2
+  - awkward  # versions controlled through uproot
+  - vector  # versions controlled through fastjet
+  - iminuit  # versions controlled through cabinetry
+  - pyhf  # versions controlled through cabinetry
+  # IRIS-HEP
+  - dask-awkward  # versions controlled through coffea
+  - xrootd>=5.6.2
+  # pip dependencies
+  - pip
+  - pip:
+    - fastjet>=3.4.0.0
+    - coffea>=2023.7.0rc0
+    - servicex>=2.7.0
+    - func-adl-servicex>=2.2
+    - func-adl  # versions controlled through servicex
+
+# conda-lock only
+platforms:
+  - linux-64

--- a/iris-hep-rc/3.8/environment.yml
+++ b/iris-hep-rc/3.8/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - pip:
     - fastjet>=3.4.0.0
     - coffea>=2023.7.0rc0
-    - servicex>=2.7.0
+    - servicex>=3.0.0a6
     - func-adl-servicex>=2.2
     - func-adl  # versions controlled through servicex
 

--- a/iris-hep-rc/3.8/requirements.txt
+++ b/iris-hep-rc/3.8/requirements.txt
@@ -1,0 +1,16 @@
+# Scikit-HEP
+uproot>=5.0.0
+hist[plot]>=2.7.0
+fastjet>=3.4.0.0
+cabinetry>=0.5.2
+awkward  # versions controlled through uproot
+vector  # versions controlled through fastjet
+iminuit  # versions controlled through cabinetry
+pyhf  # versions controlled through cabinetry
+# IRIS-HEP
+coffea>=2023.7.0rc0
+servicex>=2.7.0
+func-adl-servicex>=2.2
+xrootd>=5.6.2
+dask-awkward  # versions controlled through coffea
+func-adl  # versions controlled through servicex

--- a/iris-hep-rc/3.8/requirements.txt
+++ b/iris-hep-rc/3.8/requirements.txt
@@ -10,7 +10,7 @@ iminuit  # versions controlled through cabinetry
 pyhf  # versions controlled through cabinetry
 # IRIS-HEP
 coffea>=2023.7.0rc0
-servicex>=2.7.0
+servicex>=3.0.0a6
 func-adl-servicex>=2.2
 xrootd>=5.6.2
 dask-awkward  # versions controlled through coffea

--- a/iris-hep-rc/3.8/requirements.txt
+++ b/iris-hep-rc/3.8/requirements.txt
@@ -1,3 +1,4 @@
+--pre
 # Scikit-HEP
 uproot>=5.0.0
 hist[plot]>=2.7.0

--- a/iris-hep/3.11/environment.yml
+++ b/iris-hep/3.11/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - fastjet>=3.4.0.0
+    # - fastjet>=3.4.0.0  # TODO: Fix solve
     - coffea>=0.7.21
     - servicex>=2.7.0
     - func-adl-servicex>=2.2

--- a/iris-hep/3.11/environment.yml
+++ b/iris-hep/3.11/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - iminuit  # versions controlled through cabinetry
   - pyhf  # versions controlled through cabinetry
   # IRIS-HEP
-  - dask-awkward  # versions controlled through coffea
+  - dask-awkward>=2022.9a1 # versions controlled through coffea, last with awkward v1
   - xrootd>=5.6.2
   # pip dependencies
   - pip

--- a/iris-hep/3.11/environment.yml
+++ b/iris-hep/3.11/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - pip:
     # - fastjet>=3.4.0.0  # TODO: Fix solve
     - coffea>=0.7.21
-    - servicex>=2.7.0
+    - servicex>=2.6.2
     - func-adl-servicex>=2.2
     - func-adl  # versions controlled through servicex
 

--- a/iris-hep/3.11/environment.yml
+++ b/iris-hep/3.11/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3.11
   # Scikit-HEP
-  - uproot>=5.0.0
+  - uproot>=4.0.0  # versions controlled through coffea
   - hist>=2.7.0
   - mplhep>=0.2.16  # hist[plot]
   - cabinetry>=0.5.2
@@ -21,7 +21,7 @@ dependencies:
   - pip
   - pip:
     - fastjet>=3.4.0.0
-    - coffea>=2023.7.0rc0
+    - coffea>=0.7.21
     - servicex>=2.7.0
     - func-adl-servicex>=2.2
     - func-adl  # versions controlled through servicex

--- a/iris-hep/3.11/requirements.txt
+++ b/iris-hep/3.11/requirements.txt
@@ -12,5 +12,5 @@ coffea>=0.7.21
 servicex>=2.7.0
 func-adl-servicex>=2.2
 xrootd>=5.6.2
-dask-awkward  # versions controlled through coffea
+dask-awkward>=2022.9a1  # versions controlled through coffea, last with awkward v1
 func-adl  # versions controlled through servicex

--- a/iris-hep/3.11/requirements.txt
+++ b/iris-hep/3.11/requirements.txt
@@ -1,5 +1,5 @@
 # Scikit-HEP
-uproot>=5.0.0
+uproot>=4.0.0  # versions controlled through coffea
 hist[plot]>=2.7.0
 fastjet>=3.4.0.0
 cabinetry>=0.5.2
@@ -8,7 +8,7 @@ vector  # versions controlled through fastjet
 iminuit  # versions controlled through cabinetry
 pyhf  # versions controlled through cabinetry
 # IRIS-HEP
-coffea>=2023.7.0rc0
+coffea>=0.7.21
 servicex>=2.7.0
 func-adl-servicex>=2.2
 xrootd>=5.6.2

--- a/iris-hep/3.11/requirements.txt
+++ b/iris-hep/3.11/requirements.txt
@@ -9,7 +9,7 @@ iminuit  # versions controlled through cabinetry
 pyhf  # versions controlled through cabinetry
 # IRIS-HEP
 coffea>=0.7.21
-servicex>=2.7.0
+servicex>=2.6.2
 func-adl-servicex>=2.2
 xrootd>=5.6.2
 dask-awkward>=2022.9a1  # versions controlled through coffea, last with awkward v1

--- a/iris-hep/3.8/environment.yml
+++ b/iris-hep/3.8/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - fastjet>=3.4.0.0
+    # - fastjet>=3.4.0.0  # TODO: Fix solve
     - coffea>=0.7.21
     - servicex>=2.7.0
     - func-adl-servicex>=2.2

--- a/iris-hep/3.8/environment.yml
+++ b/iris-hep/3.8/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - iminuit  # versions controlled through cabinetry
   - pyhf  # versions controlled through cabinetry
   # IRIS-HEP
-  - dask-awkward  # versions controlled through coffea
+  - dask-awkward>=2022.9a1 # versions controlled through coffea, last with awkward v1
   - xrootd>=5.6.2
   # pip dependencies
   - pip

--- a/iris-hep/3.8/environment.yml
+++ b/iris-hep/3.8/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - pip:
     # - fastjet>=3.4.0.0  # TODO: Fix solve
     - coffea>=0.7.21
-    - servicex>=2.7.0
+    - servicex>=2.6.2
     - func-adl-servicex>=2.2
     - func-adl  # versions controlled through servicex
 

--- a/iris-hep/3.8/environment.yml
+++ b/iris-hep/3.8/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3.8
   # Scikit-HEP
-  - uproot>=5.0.0
+  - uproot>=4.0.0  # versions controlled through coffea
   - hist>=2.7.0
   - mplhep>=0.2.16  # hist[plot]
   - cabinetry>=0.5.2
@@ -21,7 +21,7 @@ dependencies:
   - pip
   - pip:
     - fastjet>=3.4.0.0
-    - coffea>=2023.7.0rc0
+    - coffea>=0.7.21
     - servicex>=2.7.0
     - func-adl-servicex>=2.2
     - func-adl  # versions controlled through servicex

--- a/iris-hep/3.8/requirements.txt
+++ b/iris-hep/3.8/requirements.txt
@@ -12,5 +12,5 @@ coffea>=0.7.21
 servicex>=2.7.0
 func-adl-servicex>=2.2
 xrootd>=5.6.2
-dask-awkward  # versions controlled through coffea
+dask-awkward>=2022.9a1  # versions controlled through coffea, last with awkward v1
 func-adl  # versions controlled through servicex

--- a/iris-hep/3.8/requirements.txt
+++ b/iris-hep/3.8/requirements.txt
@@ -1,5 +1,5 @@
 # Scikit-HEP
-uproot>=5.0.0
+uproot>=4.0.0  # versions controlled through coffea
 hist[plot]>=2.7.0
 fastjet>=3.4.0.0
 cabinetry>=0.5.2
@@ -8,7 +8,7 @@ vector  # versions controlled through fastjet
 iminuit  # versions controlled through cabinetry
 pyhf  # versions controlled through cabinetry
 # IRIS-HEP
-coffea>=2023.7.0rc0
+coffea>=0.7.21
 servicex>=2.7.0
 func-adl-servicex>=2.2
 xrootd>=5.6.2

--- a/iris-hep/3.8/requirements.txt
+++ b/iris-hep/3.8/requirements.txt
@@ -9,7 +9,7 @@ iminuit  # versions controlled through cabinetry
 pyhf  # versions controlled through cabinetry
 # IRIS-HEP
 coffea>=0.7.21
-servicex>=2.7.0
+servicex>=2.6.2
 func-adl-servicex>=2.2
 xrootd>=5.6.2
 dask-awkward>=2022.9a1  # versions controlled through coffea, last with awkward v1


### PR DESCRIPTION
```
* Use SemVer versions of coffea for iris-hep stable environment.
* Add iris-hep-rc environments.
   - Add --pre option to the release candidates requirements.txt files.
* Add iris-hep-rc environment solves to CI .
* Add iris-hep-rc environments to webpage.
```