### PR TITLE
fix: Avoid micromamba being confused by '[plot]'

### DIFF
--- a/iris-hep-rc/3.11/environment.yml
+++ b/iris-hep-rc/3.11/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   # Scikit-HEP
   - uproot>=5.0.0
   - hist>=2.7.0
-  - mplhep>=0.2.16  # hist[plot]
+  - mplhep>=0.2.16  # hist + plot
   - cabinetry>=0.5.2
   - awkward  # versions controlled through uproot
   - vector  # versions controlled through fastjet

--- a/iris-hep-rc/3.8/environment.yml
+++ b/iris-hep-rc/3.8/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   # Scikit-HEP
   - uproot>=5.0.0
   - hist>=2.7.0
-  - mplhep>=0.2.16  # hist[plot]
+  - mplhep>=0.2.16  # hist + plot
   - cabinetry>=0.5.2
   - awkward  # versions controlled through uproot
   - vector  # versions controlled through fastjet

--- a/iris-hep/3.11/environment.yml
+++ b/iris-hep/3.11/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   # Scikit-HEP
   - uproot>=4.0.0  # versions controlled through coffea
   - hist>=2.7.0
-  - mplhep>=0.2.16  # hist[plot]
+  - mplhep>=0.2.16  # hist + plot
   - cabinetry>=0.5.2
   - awkward  # versions controlled through uproot
   - vector  # versions controlled through fastjet

--- a/iris-hep/3.8/environment.yml
+++ b/iris-hep/3.8/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   # Scikit-HEP
   - uproot>=4.0.0  # versions controlled through coffea
   - hist>=2.7.0
-  - mplhep>=0.2.16  # hist[plot]
+  - mplhep>=0.2.16  # hist + plot
   - cabinetry>=0.5.2
   - awkward  # versions controlled through uproot
   - vector  # versions controlled through fastjet

--- a/scikit-hep/3.11/environment.yml
+++ b/scikit-hep/3.11/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.11
   - uproot>=5.0.0
   - hist>=2.7.0
-  - mplhep>=0.2.16  # hist[plot]
+  - mplhep>=0.2.16  # hist + plot
   - cabinetry>=0.5.2
   - awkward  # versions controlled through uproot
   - vector  # versions controlled through fastjet

--- a/scikit-hep/3.8/environment.yml
+++ b/scikit-hep/3.8/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.8
   - uproot>=5.0.0
   - hist>=2.7.0
-  - mplhep>=0.2.16  # hist[plot]
+  - mplhep>=0.2.16  # hist + plot
   - cabinetry>=0.5.2
   - awkward  # versions controlled through uproot
   - vector  # versions controlled through fastjet


### PR DESCRIPTION
* micromamba is confused by the existence of 'mplhep[plot]' in a comment, so to avoid it trying to solve for a nonexistent package configuration indicate that the plot extra is getting used.