### PR TITLE
feat: Update projects to new stable releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# GitHub syntax highlighting
+pixi.lock linguist-language=YAML linguist-generated=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
 
     - name: Build conda-lock lock file
       run: |
-        conda-lock \
+        conda-lock lock \
+            --platform linux-64 \
             --file scikit-hep/${{ matrix.python-version }}/environment.yml \
             --lockfile conda-lock.yml
 
@@ -125,7 +126,8 @@ jobs:
 
     - name: Build conda-lock lock file
       run: |
-        conda-lock \
+        conda-lock lock \
+            --platform linux-64 \
             --file iris-hep/${{ matrix.python-version }}/environment.yml \
             --lockfile conda-lock.yml
 
@@ -181,7 +183,8 @@ jobs:
 
     - name: Build conda-lock lock file
       run: |
-        conda-lock \
+        conda-lock lock \
+            --platform linux-64 \
             --file iris-hep-rc/${{ matrix.python-version }}/environment.yml \
             --lockfile conda-lock.yml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,9 @@ jobs:
     - name: Build conda-lock lock file
       run: |
         conda-lock lock \
+            --micromamba \
             --platform linux-64 \
+            --kind lock \
             --file scikit-hep/${{ matrix.python-version }}/environment.yml \
             --lockfile conda-lock.yml
 
@@ -127,7 +129,9 @@ jobs:
     - name: Build conda-lock lock file
       run: |
         conda-lock lock \
+            --micromamba \
             --platform linux-64 \
+            --kind lock \
             --file iris-hep/${{ matrix.python-version }}/environment.yml \
             --lockfile conda-lock.yml
 
@@ -184,7 +188,9 @@ jobs:
     - name: Build conda-lock lock file
       run: |
         conda-lock lock \
+            --micromamba \
             --platform linux-64 \
+            --kind lock \
             --file iris-hep-rc/${{ matrix.python-version }}/environment.yml \
             --lockfile conda-lock.yml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         python -m pip install --upgrade pip-tools
 
     - name: Build lock file
@@ -65,7 +65,10 @@ jobs:
         environment-name: conda-lock
         create-args: >-
           python=${{ matrix.python-version }}
-          conda-lock
+
+    - name: Install conda-lock from main
+      run: |
+        pipx install --force 'git+https://github.com/conda/conda-lock@main'
 
     - name: Build conda-lock lock file
       run: |
@@ -107,7 +110,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         python -m pip install --upgrade pip-tools
 
     - name: Build lock file
@@ -124,7 +127,10 @@ jobs:
         environment-name: conda-lock
         create-args: >-
           python=${{ matrix.python-version }}
-          conda-lock
+
+    - name: Install conda-lock from main
+      run: |
+        pipx install --force 'git+https://github.com/conda/conda-lock@main'
 
     - name: Build conda-lock lock file
       run: |
@@ -166,7 +172,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         python -m pip install --upgrade pip-tools
 
     - name: Build lock file
@@ -183,7 +189,10 @@ jobs:
         environment-name: conda-lock
         create-args: >-
           python=${{ matrix.python-version }}
-          conda-lock
+
+    - name: Install conda-lock from main
+      run: |
+        pipx install --force 'git+https://github.com/conda/conda-lock@main'
 
     - name: Build conda-lock lock file
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+# pixi environments
+.pixi
+*.egg-info

--- a/iris-hep-rc/3.11/environment.yml
+++ b/iris-hep-rc/3.11/environment.yml
@@ -6,25 +6,25 @@ channels:
 dependencies:
   - python=3.11
   # Scikit-HEP
-  - uproot>=5.0.0
+  - uproot>=5.0.0  # versions controlled through coffea
   - hist>=2.7.0
-  - mplhep>=0.2.16  # hist[plot]
-  - cabinetry>=0.5.2
+  - mplhep>=0.3.50  # hist + plot
+  - cabinetry>=0.6.2
   - awkward  # versions controlled through uproot
   - vector  # versions controlled through fastjet
   - iminuit  # versions controlled through cabinetry
   - pyhf  # versions controlled through cabinetry
+  - coffea>=2024.1.0
   # IRIS-HEP
-  - dask-awkward  # versions controlled through coffea
-  - xrootd>=5.6.2
+  - dask-awkward>=2024.1.0 # versions controlled through coffea, last with awkward v1
+  - xrootd>=5.7.0
+  - func-adl  # versions controlled through servicex
   # pip dependencies
   - pip
   - pip:
     - fastjet>=3.4.0.0
-    - coffea>=2023.7.0rc0
-    - servicex>=3.0.0a6
+    - servicex>=3.0.0
     - func-adl-servicex>=2.2
-    - func-adl  # versions controlled through servicex
 
 # conda-lock only
 platforms:

--- a/iris-hep-rc/3.11/environment.yml
+++ b/iris-hep-rc/3.11/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - uproot>=5.0.0  # versions controlled through coffea
   - hist>=2.7.0
   - mplhep>=0.3.50  # hist + plot
-  - cabinetry>=0.6.2
+  - cabinetry>=0.6.0
   - awkward  # versions controlled through uproot
   - vector  # versions controlled through fastjet
   - iminuit  # versions controlled through cabinetry

--- a/iris-hep-rc/3.8/environment.yml
+++ b/iris-hep-rc/3.8/environment.yml
@@ -6,25 +6,25 @@ channels:
 dependencies:
   - python=3.8
   # Scikit-HEP
-  - uproot>=5.0.0
+  - uproot>=5.0.0  # versions controlled through coffea
   - hist>=2.7.0
-  - mplhep>=0.2.16  # hist[plot]
-  - cabinetry>=0.5.2
+  - mplhep>=0.3.50  # hist + plot
+  - cabinetry>=0.6.2
   - awkward  # versions controlled through uproot
   - vector  # versions controlled through fastjet
   - iminuit  # versions controlled through cabinetry
   - pyhf  # versions controlled through cabinetry
+  - coffea>=2024.1.0
   # IRIS-HEP
-  - dask-awkward  # versions controlled through coffea
-  - xrootd>=5.6.2
+  - dask-awkward>=2024.1.0 # versions controlled through coffea, last with awkward v1
+  - xrootd>=5.7.0
+  - func-adl  # versions controlled through servicex
   # pip dependencies
   - pip
   - pip:
     - fastjet>=3.4.0.0
-    - coffea>=2023.7.0rc0
-    - servicex>=3.0.0a6
+    - servicex>=3.0.0
     - func-adl-servicex>=2.2
-    - func-adl  # versions controlled through servicex
 
 # conda-lock only
 platforms:

--- a/iris-hep-rc/3.8/environment.yml
+++ b/iris-hep-rc/3.8/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - uproot>=5.0.0  # versions controlled through coffea
   - hist>=2.7.0
   - mplhep>=0.3.50  # hist + plot
-  - cabinetry>=0.6.2
+  - cabinetry>=0.6.0
   - awkward  # versions controlled through uproot
   - vector  # versions controlled through fastjet
   - iminuit  # versions controlled through cabinetry

--- a/iris-hep/3.10/environment.yml
+++ b/iris-hep/3.10/environment.yml
@@ -1,8 +1,8 @@
-name: iris-hep-py312
+name: iris-hep-py310
 channels:
 - conda-forge
 dependencies:
-- python 3.12.*
+- python 3.10.*
 - uproot >=5.0.0
 - hist >=2.7.0
 - mplhep >=0.3.50

--- a/iris-hep/3.11/environment.yml
+++ b/iris-hep/3.11/environment.yml
@@ -1,4 +1,4 @@
-name: iris-hep-311
+name: iris-hep-py311
 channels:
 - conda-forge
 dependencies:
@@ -15,3 +15,4 @@ dependencies:
 - pip:
   - func-adl-servicex>=2.2
   - servicex>=3.0.0
+  - fastjet>=3.4.0.0

--- a/iris-hep/3.11/environment.yml
+++ b/iris-hep/3.11/environment.yml
@@ -6,25 +6,25 @@ channels:
 dependencies:
   - python=3.11
   # Scikit-HEP
-  - uproot>=4.0.0  # versions controlled through coffea
+  - uproot>=5.0.0  # versions controlled through coffea
   - hist>=2.7.0
-  - mplhep>=0.2.16  # hist[plot]
-  - cabinetry>=0.5.2
+  - mplhep>=0.3.50  # hist + plot
+  - cabinetry>=0.6.2
   - awkward  # versions controlled through uproot
   - vector  # versions controlled through fastjet
   - iminuit  # versions controlled through cabinetry
   - pyhf  # versions controlled through cabinetry
+  - coffea>=2024.1.0
   # IRIS-HEP
-  - dask-awkward>=2022.9a1 # versions controlled through coffea, last with awkward v1
-  - xrootd>=5.6.2
+  - dask-awkward>=2024.1.0 # versions controlled through coffea, last with awkward v1
+  - xrootd>=5.7.0
+  - func-adl  # versions controlled through servicex
   # pip dependencies
   - pip
   - pip:
     # - fastjet>=3.4.0.0  # TODO: Fix solve
-    - coffea>=0.7.21
-    - servicex>=2.6.2
+    - servicex>=3.0.0
     - func-adl-servicex>=2.2
-    - func-adl  # versions controlled through servicex
 
 # conda-lock only
 platforms:

--- a/iris-hep/3.11/environment.yml
+++ b/iris-hep/3.11/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - uproot>=5.0.0  # versions controlled through coffea
   - hist>=2.7.0
   - mplhep>=0.3.50  # hist + plot
-  - cabinetry>=0.6.2
+  - cabinetry>=0.6.0
   - awkward  # versions controlled through uproot
   - vector  # versions controlled through fastjet
   - iminuit  # versions controlled through cabinetry

--- a/iris-hep/3.12/environment.yml
+++ b/iris-hep/3.12/environment.yml
@@ -1,8 +1,8 @@
-name: iris-hep-311
+name: iris-hep-312
 channels:
 - conda-forge
 dependencies:
-- python 3.11.*
+- python 3.12.*
 - uproot >=5.0.0
 - hist >=2.7.0
 - mplhep >=0.3.50

--- a/iris-hep/3.8/environment.yml
+++ b/iris-hep/3.8/environment.yml
@@ -1,31 +1,18 @@
-name: iris-hep
-
+name: iris-hep-py38
 channels:
-  - conda-forge
-
+- conda-forge
 dependencies:
-  - python=3.8
-  # Scikit-HEP
-  - uproot>=5.0.0  # versions controlled through coffea
-  - hist>=2.7.0
-  - mplhep>=0.3.50  # hist + plot
-  - cabinetry>=0.6.0
-  - awkward  # versions controlled through uproot
-  - vector  # versions controlled through fastjet
-  - iminuit  # versions controlled through cabinetry
-  - pyhf  # versions controlled through cabinetry
+- python 3.8.*
+- uproot >=5.0.0
+- hist >=2.7.0
+- mplhep >=0.3.50
+- cabinetry >=0.6.0
+- func-adl >=3.3.0
+- xrootd >=5.7.0
+- dask-awkward >=2024.1.0
+- pip
+- pip:
   - coffea>=2024.1.0
-  # IRIS-HEP
-  - dask-awkward>=2024.1.0 # versions controlled through coffea, last with awkward v1
-  - xrootd>=5.7.0
-  - func-adl  # versions controlled through servicex
-  # pip dependencies
-  - pip
-  - pip:
-    # - fastjet>=3.4.0.0  # TODO: Fix solve
-    - servicex>=3.0.0
-    - func-adl-servicex>=2.2
-
-# conda-lock only
-platforms:
-  - linux-64
+  - func-adl-servicex>=2.2
+  - servicex>=3.0.0
+  - fastjet>=3.4.0.0

--- a/iris-hep/3.8/environment.yml
+++ b/iris-hep/3.8/environment.yml
@@ -6,25 +6,25 @@ channels:
 dependencies:
   - python=3.8
   # Scikit-HEP
-  - uproot>=4.0.0  # versions controlled through coffea
+  - uproot>=5.0.0  # versions controlled through coffea
   - hist>=2.7.0
-  - mplhep>=0.2.16  # hist[plot]
-  - cabinetry>=0.5.2
+  - mplhep>=0.3.50  # hist + plot
+  - cabinetry>=0.6.2
   - awkward  # versions controlled through uproot
   - vector  # versions controlled through fastjet
   - iminuit  # versions controlled through cabinetry
   - pyhf  # versions controlled through cabinetry
+  - coffea>=2024.1.0
   # IRIS-HEP
-  - dask-awkward>=2022.9a1 # versions controlled through coffea, last with awkward v1
-  - xrootd>=5.6.2
+  - dask-awkward>=2024.1.0 # versions controlled through coffea, last with awkward v1
+  - xrootd>=5.7.0
+  - func-adl  # versions controlled through servicex
   # pip dependencies
   - pip
   - pip:
     # - fastjet>=3.4.0.0  # TODO: Fix solve
-    - coffea>=0.7.21
-    - servicex>=2.6.2
+    - servicex>=3.0.0
     - func-adl-servicex>=2.2
-    - func-adl  # versions controlled through servicex
 
 # conda-lock only
 platforms:

--- a/iris-hep/3.8/environment.yml
+++ b/iris-hep/3.8/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - uproot>=5.0.0  # versions controlled through coffea
   - hist>=2.7.0
   - mplhep>=0.3.50  # hist + plot
-  - cabinetry>=0.6.2
+  - cabinetry>=0.6.0
   - awkward  # versions controlled through uproot
   - vector  # versions controlled through fastjet
   - iminuit  # versions controlled through cabinetry

--- a/iris-hep/3.9/environment.yml
+++ b/iris-hep/3.9/environment.yml
@@ -1,4 +1,4 @@
-name: iris-hep-39
+name: iris-hep-py39
 channels:
 - conda-forge
 dependencies:
@@ -15,3 +15,4 @@ dependencies:
 - pip:
   - func-adl-servicex>=2.2
   - servicex>=3.0.0
+  - fastjet>=3.4.0.0

--- a/iris-hep/3.9/environment.yml
+++ b/iris-hep/3.9/environment.yml
@@ -1,8 +1,8 @@
-name: iris-hep-311
+name: iris-hep-39
 channels:
 - conda-forge
 dependencies:
-- python 3.11.*
+- python 3.9.*
 - uproot >=5.0.0
 - hist >=2.7.0
 - mplhep >=0.3.50

--- a/pixi.toml
+++ b/pixi.toml
@@ -56,27 +56,16 @@ func-adl-servicex = ">=2.2"
 servicex = ">=3.0.0"  # versions controlled through func-adl-servicex
 fastjet = ">=3.4.0.0"
 
-[feature.iris-hep-py38-pypi.dependencies]
-python = "3.8.*"
-xrootd = ">=5.7.0"
+[feature.iris-hep-py38.tasks]
+export-env = """
+mkdir -p iris-hep/3.8 && \
+pixi project export conda-environment --environment iris-hep-py38 iris-hep/3.8/environment.yml
+"""
 
-[feature.iris-hep-py38-pypi.pypi-dependencies]
-# Scikit-HEP
-uproot = ">=5.0.0"  # versions controlled through coffea
-hist = ">=2.7.0"
-mplhep = ">=0.3.50"  # hist + plot
-cabinetry = ">=0.6.0"
-coffea = ">=2024.1.0"
-# awkward = "*"  # versions controlled through uproot
-# vector = "*"  # versions controlled through fastjet
-# iminuit = "*" # versions controlled through cabinetry
-# pyhf = "*"  # versions controlled through cabinetry
-# IRIS-HEP
-func-adl = ">=3.3.0"  # versions controlled through servicex
-dask-awkward = ">=2024.1.0"  # versions controlled through coffea
-func-adl-servicex = ">=2.2"
-servicex = ">=3.0.0"  # versions controlled through func-adl-servicex
-fastjet = ">=3.4.0.0"
+export-spec = """
+mkdir -p iris-hep/3.8 && \
+pixi project export conda-explicit-spec --environment iris-hep-py38 --locked --ignore-pypi-errors iris-hep/3.8/
+"""
 
 [feature.py39.dependencies]
 python = "3.9.*"
@@ -84,12 +73,26 @@ python = "3.9.*"
 [feature.py39.tasks]
 export-env = """
 mkdir -p iris-hep/3.9 && \
-pixi project export conda-environment --environment iris-hep-39 iris-hep/3.9/environment.yml
+pixi project export conda-environment --environment iris-hep-py39 iris-hep/3.9/environment.yml
 """
 
 export-spec = """
 mkdir -p iris-hep/3.9 && \
-pixi project export conda-explicit-spec --environment iris-hep-39 --locked --ignore-pypi-errors iris-hep/3.9/
+pixi project export conda-explicit-spec --environment iris-hep-py39 --locked --ignore-pypi-errors iris-hep/3.9/
+"""
+
+[feature.py310.dependencies]
+python = "3.10.*"
+
+[feature.py310.tasks]
+export-env = """
+mkdir -p iris-hep/3.10 && \
+pixi project export conda-environment --environment iris-hep-py310 iris-hep/3.10/environment.yml
+"""
+
+export-spec = """
+mkdir -p iris-hep/3.10 && \
+pixi project export conda-explicit-spec --environment iris-hep-py310 --locked --ignore-pypi-errors iris-hep/3.10/
 """
 
 [feature.py311.dependencies]
@@ -98,12 +101,12 @@ python = "3.11.*"
 [feature.py311.tasks]
 export-env = """
 mkdir -p iris-hep/3.11 && \
-pixi project export conda-environment --environment iris-hep-311 iris-hep/3.11/environment.yml
+pixi project export conda-environment --environment iris-hep-py311 iris-hep/3.11/environment.yml
 """
 
 export-spec = """
 mkdir -p iris-hep/3.11 && \
-pixi project export conda-explicit-spec --environment iris-hep-311 --locked --ignore-pypi-errors iris-hep/3.11/
+pixi project export conda-explicit-spec --environment iris-hep-py311 --locked --ignore-pypi-errors iris-hep/3.11/
 """
 
 [feature.py312.dependencies]
@@ -112,12 +115,12 @@ python = "3.12.*"
 [feature.py312.tasks]
 export-env = """
 mkdir -p iris-hep/3.12 && \
-pixi project export conda-environment --environment iris-hep-312 iris-hep/3.12/environment.yml
+pixi project export conda-environment --environment iris-hep-py312 iris-hep/3.12/environment.yml
 """
 
 export-spec = """
 mkdir -p iris-hep/3.12 && \
-pixi project export conda-explicit-spec --environment iris-hep-312 --locked --ignore-pypi-errors iris-hep/3.12/
+pixi project export conda-explicit-spec --environment iris-hep-py312 --locked --ignore-pypi-errors iris-hep/3.12/
 """
 
 [environments]
@@ -126,9 +129,9 @@ iris-hep = ["iris-hep"]
 
 iris-hep-py38 = ["iris-hep-py38"]
 
-iris-hep-py38-pypi = ["iris-hep-py38-pypi"]
-
 iris-hep-py39 = ["py39", "iris-hep"]
+
+iris-hep-py310 = ["py310", "iris-hep"]
 
 iris-hep-py311 = ["py311", "iris-hep"]
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -29,6 +29,7 @@ dask-awkward = ">=2024.1.0"  # versions controlled through coffea
 [feature.iris-hep.pypi-dependencies]
 func-adl-servicex = ">=2.2"
 servicex = ">=3.0.0"  # versions controlled through func-adl-servicex
+fastjet = ">=3.4.0.0"
 
 [feature.py39.dependencies]
 python = "3.9.*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -22,7 +22,7 @@ coffea = ">=2024.1.0"
 # iminuit = "*" # versions controlled through cabinetry
 # pyhf = "*"  # versions controlled through cabinetry
 # IRIS-HEP
-func-adl = "*"  # versions controlled through servicex
+func-adl = ">=3.3.0"  # versions controlled through servicex
 xrootd = ">=5.7.0"
 dask-awkward = ">=2024.1.0"  # versions controlled through coffea
 
@@ -33,11 +33,44 @@ servicex = ">=3.0.0"  # versions controlled through func-adl-servicex
 [feature.py39.dependencies]
 python = "3.9.*"
 
+[feature.py39.tasks]
+export-env = """
+mkdir -p iris-hep/3.9 && \
+pixi project export conda-environment --environment iris-hep-39 iris-hep/3.9/environment.yml
+"""
+
+export-spec = """
+mkdir -p iris-hep/3.9 && \
+pixi project export conda-explicit-spec --environment iris-hep-39 --locked --ignore-pypi-errors iris-hep/3.9/
+"""
+
 [feature.py311.dependencies]
 python = "3.11.*"
 
+[feature.py311.tasks]
+export-env = """
+mkdir -p iris-hep/3.11 && \
+pixi project export conda-environment --environment iris-hep-311 iris-hep/3.11/environment.yml
+"""
+
+export-spec = """
+mkdir -p iris-hep/3.11 && \
+pixi project export conda-explicit-spec --environment iris-hep-311 --locked --ignore-pypi-errors iris-hep/3.11/
+"""
+
 [feature.py312.dependencies]
 python = "3.12.*"
+
+[feature.py312.tasks]
+export-env = """
+mkdir -p iris-hep/3.12 && \
+pixi project export conda-environment --environment iris-hep-312 iris-hep/3.12/environment.yml
+"""
+
+export-spec = """
+mkdir -p iris-hep/3.12 && \
+pixi project export conda-explicit-spec --environment iris-hep-312 --locked --ignore-pypi-errors iris-hep/3.12/
+"""
 
 [environments]
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,6 +31,53 @@ func-adl-servicex = ">=2.2"
 servicex = ">=3.0.0"  # versions controlled through func-adl-servicex
 fastjet = ">=3.4.0.0"
 
+[feature.iris-hep-py38.dependencies]
+python = "3.8.*"
+# Scikit-HEP
+uproot = ">=5.0.0"  # versions controlled through coffea
+hist = ">=2.7.0"
+mplhep = ">=0.3.50"  # hist + plot
+cabinetry = ">=0.6.0"
+# coffea = ">=2024.1.0"
+# awkward = "*"  # versions controlled through uproot
+# vector = "*"  # versions controlled through fastjet
+# iminuit = "*" # versions controlled through cabinetry
+# pyhf = "*"  # versions controlled through cabinetry
+# IRIS-HEP
+func-adl = ">=3.3.0"  # versions controlled through servicex
+xrootd = ">=5.7.0"
+dask-awkward = ">=2024.1.0"  # versions controlled through coffea
+
+[feature.iris-hep-py38.pypi-dependencies]
+# coffea on conda-forge seems to be misspecified for Python 3.8
+# as only works for coffea = ">=2024.1.0,<2024.3.0"
+coffea = ">=2024.1.0"
+func-adl-servicex = ">=2.2"
+servicex = ">=3.0.0"  # versions controlled through func-adl-servicex
+fastjet = ">=3.4.0.0"
+
+[feature.iris-hep-py38-pypi.dependencies]
+python = "3.8.*"
+xrootd = ">=5.7.0"
+
+[feature.iris-hep-py38-pypi.pypi-dependencies]
+# Scikit-HEP
+uproot = ">=5.0.0"  # versions controlled through coffea
+hist = ">=2.7.0"
+mplhep = ">=0.3.50"  # hist + plot
+cabinetry = ">=0.6.0"
+coffea = ">=2024.1.0"
+# awkward = "*"  # versions controlled through uproot
+# vector = "*"  # versions controlled through fastjet
+# iminuit = "*" # versions controlled through cabinetry
+# pyhf = "*"  # versions controlled through cabinetry
+# IRIS-HEP
+func-adl = ">=3.3.0"  # versions controlled through servicex
+dask-awkward = ">=2024.1.0"  # versions controlled through coffea
+func-adl-servicex = ">=2.2"
+servicex = ">=3.0.0"  # versions controlled through func-adl-servicex
+fastjet = ">=3.4.0.0"
+
 [feature.py39.dependencies]
 python = "3.9.*"
 
@@ -77,8 +124,12 @@ pixi project export conda-explicit-spec --environment iris-hep-312 --locked --ig
 
 iris-hep = ["iris-hep"]
 
-iris-hep-39 = ["py39", "iris-hep"]
+iris-hep-py38 = ["iris-hep-py38"]
 
-iris-hep-311 = ["py311", "iris-hep"]
+iris-hep-py38-pypi = ["iris-hep-py38-pypi"]
 
-iris-hep-312 = ["py312", "iris-hep"]
+iris-hep-py39 = ["py39", "iris-hep"]
+
+iris-hep-py311 = ["py311", "iris-hep"]
+
+iris-hep-py312 = ["py312", "iris-hep"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,50 @@
+[project]
+authors = ["Matthew Feickert <matthew.feickert@cern.ch>"]
+channels = ["conda-forge"]
+description = "Add a short description here"
+name = "analysis-systems-env-nightlies"
+platforms = ["linux-64"]
+version = "0.1.0"
+
+[tasks]
+
+[dependencies]
+
+[feature.iris-hep.dependencies]
+# Scikit-HEP
+uproot = ">=5.0.0"  # versions controlled through coffea
+hist = ">=2.7.0"
+mplhep = ">=0.3.50"  # hist + plot
+cabinetry = ">=0.6.0"
+coffea = ">=2024.1.0"
+# awkward = "*"  # versions controlled through uproot
+# vector = "*"  # versions controlled through fastjet
+# iminuit = "*" # versions controlled through cabinetry
+# pyhf = "*"  # versions controlled through cabinetry
+# IRIS-HEP
+func-adl = "*"  # versions controlled through servicex
+xrootd = ">=5.7.0"
+dask-awkward = ">=2024.1.0"  # versions controlled through coffea
+
+[feature.iris-hep.pypi-dependencies]
+func-adl-servicex = ">=2.2"
+servicex = ">=3.0.0"  # versions controlled through func-adl-servicex
+
+[feature.py39.dependencies]
+python = "3.9.*"
+
+[feature.py311.dependencies]
+python = "3.11.*"
+
+[feature.py312.dependencies]
+python = "3.12.*"
+
+[environments]
+
+iris-hep = ["iris-hep"]
+
+iris-hep-39 = ["py39", "iris-hep"]
+
+iris-hep-311 = ["py311", "iris-hep"]
+
+iris-hep-312 = ["py312", "iris-hep"]


### PR DESCRIPTION
* Update projects to new releases.
* Use the conda-forge versions of coffea and func-adl.
* Update coffea to CalVer.
* Update serviceX client to v3.0.0.