### PR TITLE
fix: Install conda-lock from HEAD on GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         python -m pip install --upgrade pip-tools
 
     - name: Build lock file
@@ -65,7 +65,10 @@ jobs:
         environment-name: conda-lock
         create-args: >-
           python=${{ matrix.python-version }}
-          conda-lock
+
+    - name: Install conda-lock from main
+      run: |
+        pipx install --force 'git+https://github.com/conda/conda-lock@main'
 
     - name: Build conda-lock lock file
       run: |
@@ -104,7 +107,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         python -m pip install --upgrade pip-tools
 
     - name: Build lock file
@@ -121,7 +124,10 @@ jobs:
         environment-name: conda-lock
         create-args: >-
           python=${{ matrix.python-version }}
-          conda-lock
+
+    - name: Install conda-lock from main
+      run: |
+        pipx install --force 'git+https://github.com/conda/conda-lock@main'
 
     - name: Build conda-lock lock file
       run: |
@@ -160,7 +166,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         python -m pip install --upgrade pip-tools
 
     - name: Build lock file
@@ -177,7 +183,10 @@ jobs:
         environment-name: conda-lock
         create-args: >-
           python=${{ matrix.python-version }}
-          conda-lock
+
+    - name: Install conda-lock from main
+      run: |
+        pipx install --force 'git+https://github.com/conda/conda-lock@main'
 
     - name: Build conda-lock lock file
       run: |


### PR DESCRIPTION
* Use `pipx` to install `conda-lock` from `HEAD` given that `conda-lock` ([`v2.5.7`](https://github.com/conda/conda-lock/releases/tag/v2.5.7)) has a major bug given the vendored Poetry solver that makes `conda-lock` unusable. This has already been fixed but a new post 2.5.7 release has yet to be made, so on recommendations from the developer team install conda-lock from GitHub HEAD.

c.f. https://github.com/conda/conda-lock/issues/619#issuecomment-2390799528