### PR TITLE
ci: Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
     labels:
       - "github-actions"
+    reviewers:
+      - "matthewfeickert"


### PR DESCRIPTION
* Group dependabot updates to reduce the number of PRs.
   - c.f. sp-repo-review GH212: Require GHA update grouping https://learn.scientific-python.org/development/guides/gha-basic/#GH212