### PR TITLE
ci: Use uv to compile lock file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
       run: |
         uv pip compile \
           --generate-hashes \
-          --output-file=requirements.lock \
+          --output-file requirements.lock \
+          --python-version ${{ matrix.python-version }} \
           scikit-hep/${{ matrix.python-version }}/requirements.txt
 
     - name: Install micromamba and conda-lock
@@ -113,7 +114,8 @@ jobs:
       run: |
         uv pip compile \
           --generate-hashes \
-          --output-file=requirements.lock \
+          --output-file requirements.lock \
+          --python-version ${{ matrix.python-version }} \
           iris-hep/${{ matrix.python-version }}/requirements.txt
 
     - name: Install micromamba and conda-lock
@@ -176,8 +178,9 @@ jobs:
       run: |
         uv pip compile \
           --generate-hashes \
-          --prerelease=if-necessary \
-          --output-file=requirements.lock \
+          --prerelease if-necessary \
+          --output-file requirements.lock \
+          --python-version ${{ matrix.python-version }} \
           iris-hep-rc/${{ matrix.python-version }}/requirements.txt
 
     - name: Install micromamba and conda-lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,17 +46,16 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade pip-tools
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "latest"
 
     - name: Build lock file
       run: |
-        pip-compile \
-          --resolver=backtracking \
+        uv pip compile \
           --generate-hashes \
-          --output-file requirements.lock \
+          --output-file=requirements.lock \
           scikit-hep/${{ matrix.python-version }}/requirements.txt
 
     - name: Install micromamba and conda-lock
@@ -105,17 +104,16 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade pip-tools
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "latest"
 
     - name: Build lock file
       run: |
-        pip-compile \
-          --resolver=backtracking \
+        uv pip compile \
           --generate-hashes \
-          --output-file requirements.lock \
+          --output-file=requirements.lock \
           iris-hep/${{ matrix.python-version }}/requirements.txt
 
     - name: Install micromamba and conda-lock
@@ -169,12 +167,17 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade pip-tools
 
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "latest"
+
     - name: Build lock file
       run: |
-        pip-compile \
-          --resolver=backtracking \
+        uv pip compile \
           --generate-hashes \
-          --output-file requirements.lock \
+          --prerelease=if-necessary \
+          --output-file=requirements.lock \
           iris-hep-rc/${{ matrix.python-version }}/requirements.txt
 
     - name: Install micromamba and conda-lock

--- a/iris-hep-rc/3.11/requirements.txt
+++ b/iris-hep-rc/3.11/requirements.txt
@@ -1,4 +1,3 @@
---pre
 # Scikit-HEP
 uproot>=5.0.0
 hist[plot]>=2.7.0

--- a/iris-hep-rc/3.12/requirements.txt
+++ b/iris-hep-rc/3.12/requirements.txt
@@ -1,4 +1,3 @@
---pre
 # Scikit-HEP
 uproot>=5.0.0
 hist[plot]>=2.7.0

--- a/iris-hep-rc/3.8/requirements.txt
+++ b/iris-hep-rc/3.8/requirements.txt
@@ -1,4 +1,3 @@
---pre
 # Scikit-HEP
 uproot>=5.0.0
 hist[plot]>=2.7.0


### PR DESCRIPTION
* Use https://github.com/astral-sh/setup-uv to setup uv.
* Use 'uv pip compile' to generate Python lock files.